### PR TITLE
link reads .close_token

### DIFF
--- a/src/sdk/dslink/link.cc
+++ b/src/sdk/dslink/link.cc
@@ -82,6 +82,13 @@ DsLink::DsLink(int argc, const char *argv[], const string_ &link_name,
     }
   }
 
+  try{
+    close_token = string_from_file(".close_token");
+    if(close_token.length() != 32) throw std::runtime_error("Token is not have 32 length");
+  }catch(std::exception &e){
+    close_token = "";
+  }
+
   parse_url(variables["broker"].as<string_>());
   parse_name(variables["name"].as<string_>());
   parse_log(variables["log"].as<string_>(), *strand);
@@ -301,5 +308,8 @@ ref_<IncomingSetStream> DsLink::set(IncomingSetStreamCallback &&callback,
                                     ref_<const SetRequestMessage> &&message) {
   return _client->get_session().requester.set(std::move(callback),
                                               std::move(message));
+}
+string_ DsLink::get_close_token() {
+  return close_token;
 }
 }

--- a/src/sdk/dslink/link.h
+++ b/src/sdk/dslink/link.h
@@ -30,6 +30,7 @@ class DsLink final : public WrapperStrand {
          const string_ &version, const shared_ptr_<App> &app = nullptr);
   ~DsLink() final;
   App &get_app();
+  string_ get_close_token();
 
  protected:
   void destroy_impl() final;
@@ -39,6 +40,8 @@ class DsLink final : public WrapperStrand {
   shared_ptr_<TcpServer> _tcp_server;
   ref_<Client> _client;
   ref_<LinkRoot> _root;
+
+  string_ close_token;
 
   bool _running = false;
   bool _connected = false;

--- a/src/sdk/dslink/node/sys_root.cc
+++ b/src/sdk/dslink/node/sys_root.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "dsa_common.h"
 
 #include "sys_root.h"
@@ -9,13 +10,19 @@ namespace dsa {
 
 LinkSysRoot::LinkSysRoot(LinkStrandRef &&strand, ref_<DsLink> &&link)
     : NodeModel(std::move(strand)) {
-  add_list_child(
-      "stop", make_ref_<SimpleInvokeNode>(_strand->get_ref(),
-                                          [link = std::move(link)](Var && v) {
-                                            link->destroy();
-                                            return Var();
-                                          },
-                                          PermissionLevel::CONFIG));
+  if (link->get_close_token() != "") {
+    add_list_child(
+        "stop", make_ref_<SimpleInvokeNode>(_strand->get_ref(),
+                                            [link = std::move(link)](Var &&v) {
+                                              //Checking Token
+                                              if (v.get_type() == Var::STRING &&
+                                                  link->get_close_token() == v.get_string()) {
+                                                link->destroy();
+                                              }
+                                              return Var();
+                                            },
+                                            PermissionLevel::CONFIG));
+  }
 }
 LinkSysRoot::~LinkSysRoot() = default;
 }

--- a/src/sdk/responder/invoke_node_model.cc
+++ b/src/sdk/responder/invoke_node_model.cc
@@ -41,6 +41,9 @@ void SimpleInvokeNode::on_invoke(ref_<OutgoingInvokeStream> &&stream,
                                  ref_<NodeState> &parent) {
   stream->on_request(([this](OutgoingInvokeStream &s,
                              ref_<const InvokeRequestMessage> &&message) {
+    if (message == nullptr) {
+      return; // nullptr is for destroyed callback, no need to handle here
+    }
     Var result = _callback(message->get_value());
     auto response = make_ref_<InvokeResponseMessage>();
 

--- a/test/sdk/dslink/dslink-server-test.cc
+++ b/test/sdk/dslink/dslink-server-test.cc
@@ -1,3 +1,4 @@
+#include <util/string.h>
 #include "dsa/network.h"
 #include "dsa/responder.h"
 #include "dsa/stream.h"
@@ -5,6 +6,9 @@
 #include "../async_test.h"
 #include "../test_config.h"
 #include "gtest/gtest.h"
+
+#include "message/request/invoke_request_message.h"
+
 
 using namespace dsa;
 using namespace std;
@@ -28,6 +32,7 @@ class ExampleNodeRoot : public NodeModel {
   };
 };
 
+
 TEST(DSLinkTest, Server_Test) {
   shared_ptr<App> app = make_shared<App>();
 
@@ -45,8 +50,6 @@ TEST(DSLinkTest, Server_Test) {
   const char *argv2[] = {"./test", "-b", address.c_str()};
   int argc2 = 3;
   auto link = make_ref_<DsLink>(argc2, argv2, "mydslink", "1.0.0", app);
-
-
 
 // connection
   bool is_connected = false;
@@ -93,3 +96,73 @@ TEST(DSLinkTest, Server_Test) {
   app->wait();
 
 }
+
+TEST(DSLinkTest, CloseTest) {
+  shared_ptr<App> app = make_shared<App>();
+
+  // first create .close_token
+  string_ close_token = "12345678901234567890123456789012";
+  try{
+    close_token = string_from_file(".close_token");
+  }catch(std::exception &e){
+    string_to_file(close_token, ".close_token");
+  }
+
+  const char
+      *argv[] = {"./testResp", "--broker", "ds://127.0.0.1:4120", "-l", "info", "--thread", "4", "--server-port", "4121"};
+  int argc = 9;
+  auto linkResp = make_ref_<DsLink>(argc, argv, "mydslink", "1.0.0");
+  linkResp->init_responder<ExampleNodeRoot>();
+  linkResp->connect([&](const shared_ptr_<Connection> connection) {});
+
+  EXPECT_EQ(close_token, linkResp->get_close_token());
+
+// Create link
+  std::string address =
+      std::string("127.0.0.1:") + std::to_string(4121);
+
+  const char *argv2[] = {"./test", "-b", address.c_str()};
+  int argc2 = 3;
+  auto link = make_ref_<DsLink>(argc2, argv2, "mydslink", "1.0.0", app);
+
+// connection
+  bool is_connected = false;
+  link->connect([&](const shared_ptr_<Connection> connection) { is_connected = true; });
+
+  ASYNC_EXPECT_TRUE(500, *link->strand, [&]() { return is_connected; });
+
+  auto close_request_with_wrong_token = make_ref_<InvokeRequestMessage>();
+  close_request_with_wrong_token->set_value(Var("wrongtoken"));
+  close_request_with_wrong_token->set_target_path("sys/stop");
+
+  link->invoke( [&](IncomingInvokeStream &stream,
+                    ref_<const InvokeResponseMessage> &&msg) {
+                },
+                copy_ref_(close_request_with_wrong_token));
+
+  WAIT(1000);
+  EXPECT_FALSE(linkResp->is_destroyed());
+
+  auto close_request_with_valid_token = make_ref_<InvokeRequestMessage>();
+  close_request_with_wrong_token->set_value(Var(close_token));
+  close_request_with_wrong_token->set_target_path("sys/stop");
+
+  link->invoke( [&](IncomingInvokeStream &stream,
+                    ref_<const InvokeResponseMessage> &&msg) {
+                },
+                copy_ref_(close_request_with_wrong_token));
+
+  ASYNC_EXPECT_TRUE(1000, *linkResp->strand, [&]() { return linkResp->is_destroyed(); });
+
+  destroy_dslink_in_strand(link);
+
+  app->close();
+  WAIT_EXPECT_TRUE(500, [&]() -> bool { return app->is_stopped(); });
+
+  if (!app->is_stopped()) {
+    app->force_stop();
+  }
+  app->wait();
+
+}
+


### PR DESCRIPTION
stop is not node member if there is no .close_token
stop is working only with valid token, if not ignoring the stop invoke
**tests implemented, but suspicious there is problem on close invoke. Need to check for @rick**